### PR TITLE
Peer to peer

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -53,7 +53,7 @@ export function connect() {
       {
         let conn = peer.connect(hostId)
         // Keep track of connections
-        console.log("Conn ", conn)
+        console.log("Connecting to host ", conn)
         connections.add(conn)
         peer.on('connection', (clientConnection) => {
           connections.add(clientConnection)
@@ -65,7 +65,7 @@ export function connect() {
             console.log("otherClientId: ", otherClientId)
             clientConnection.on('data', (data) => {
               // Add to clients inState
-              console.log("Client: Got data from another client: ", data)
+              //console.log("Client: Got data from another client: ", data)
               inState.push(data)
             })
           })
@@ -80,7 +80,7 @@ export function connect() {
           console.log("ClientId: ", clientId)
           conn.on('data', (data) => {
             // Add to clients inState
-            console.log("Client: Got data: ", data)
+            //console.log("Client: Got data: ", data)
             if (data.command == NetCommandId.connectToPeers) {
               data.peers.forEach(peer => {
                 makePeerConnection(peer)
@@ -146,10 +146,10 @@ function makePeerConnection(peerId) {
   console.log("Connected to other client ", conn)
   connections.add(conn)
   conn.on('open', () => {
-    console.log("Connection opened between two clients", conn)
+    console.log("Connection opened to another client", conn)
     conn.on('data', (data) => {
       // Add to clients inState
-      console.log("Client: Got data from other client: ", data)
+      //console.log("Client: Got data from another client: ", data)
       inState.push(data)
     })
   })

--- a/src/network.js
+++ b/src/network.js
@@ -56,6 +56,7 @@ export function connect() {
         connections.add(conn)
         conn.on('open', () => {
           console.log("Peer opened as client")
+          connected = true
           conn.on('data', (data) => {
             // Add to clients inState
             //console.log("Got data: ", data)

--- a/src/occult-it.js
+++ b/src/occult-it.js
@@ -8,6 +8,7 @@ import { Console } from './console.js'
 import { getNetworkId, inState, singlePlayer, isConnected, isHost, NetCommandId, setOutState } from './network.js'
 import { addWalls, loadWWallSprites } from './walls.js'
 import { addFloorAssets, addFloorSprites } from './floor.js'
+import _ from 'lodash'
 
 export class OccultIt {
     engine
@@ -272,6 +273,14 @@ F/Ctrl: Fix
                         state.players.push(playerState)
                         this.gameContainer.addChild(player.sprite)
                     }
+                } else if (aNewState.command == NetCommandId.removePlayer) {
+                    const removedPlayers = _.remove(this.players, p => p.movement.id == aNewState.id)
+                    _.remove(state.players, p => p.id == aNewState.id)
+
+                    removedPlayers.forEach(removedPlayer => {
+                        console.log("Removing player: ", removedPlayer.movement.id)
+                        this.gameContainer.removeChild(removedPlayer.sprite)
+                    });
                 } else if (aNewState.command == NetCommandId.pipe) {
                     updatePipeState(aNewState.pipe, this.gameContainer)
                 }

--- a/src/occult-it.js
+++ b/src/occult-it.js
@@ -215,16 +215,15 @@ F/Ctrl: Fix
         if (inState.length > 0) {
             const aNewState = inState.shift()
 
-            console.log("Got state", aNewState)
+            //console.log("Got state", aNewState)
             if (aNewState.command == NetCommandId.game) {
+                console.log("Received game state: ", aNewState)
                 while (this.gameContainer.children.length > 0) {
                     this.gameContainer.removeChild(this.gameContainer.children[0])
                 }
-                console.log("Cleared container")
                 this.players = []
                 state.tiles = aNewState.state.tiles
                 state.players = aNewState.state.players
-                console.log("Players: ", state.players)
                 state.console = aNewState.state.console
                 this.theConsole.setState(state.console)
 
@@ -238,6 +237,8 @@ F/Ctrl: Fix
 
                 window.players = this.players
 
+                console.log("Players in new game: ", state.players)
+
                 this.addSprites()
                 setOutState({
                     command: NetCommandId.player,
@@ -245,11 +246,11 @@ F/Ctrl: Fix
                 })
             } else if (state.tiles) {
                 if (aNewState.command == NetCommandId.player) {
-                    console.log(aNewState.movement.id)
+                    // console.log(aNewState.movement.id)
                     const updatePlayer = this.players.find(p => p.movement.id == aNewState.movement.id)
 
                     if (updatePlayer) {
-                        console.log("Updating player", updatePlayer)
+                        // console.log("Updating player", updatePlayer)
                         const updateStateIndex = state.players.findIndex(ps => ps.id == aNewState.movement.id)
                         
                         aNewState.movement.pos = new Vector2(aNewState.movement.pos.x, aNewState.movement.pos.y)
@@ -263,6 +264,7 @@ F/Ctrl: Fix
                             }
                     } else {
                         // a new player 
+                        console.log("Adding player: ", aNewState.movement.id)
                         const playerState = {
                             id: aNewState.movement.id,
                             pos: new Vector2(aNewState.movement.pos.x, aNewState.movement.pos.y),


### PR DESCRIPTION
 When a client connects the host tells it the ids of all other connected clients. The connecting client also connects to those clients.

Remove connections when they close. Remove the player and player-state associated with that player.

Host migration not supported; players continue to move but no more pipes will be broken and no new players will be able to join the session.

Fix bug where continue-create wasn't happening for clients

Minor Bug: When a new client connects their player will not immediately appear in other clients but when they move they appear.
